### PR TITLE
feat: check for required environment variables

### DIFF
--- a/src/archiver.ts
+++ b/src/archiver.ts
@@ -262,7 +262,7 @@ export class Archiver extends Construct {
         buildSpec: codebuild.BuildSpec.fromObject({
           version: 0.2,
           batch: {
-            'fail-fast': false,
+            'fast-fail': false,
             'build-list': this.createBatchConfiguration(
               element.repositoryNames,
             ),

--- a/src/archiver.ts
+++ b/src/archiver.ts
@@ -268,6 +268,15 @@ export class Archiver extends Construct {
             ),
           },
           phases: {
+            pre_build: {
+              'commands': [
+                'if [ -z "${ORGANIZATION}" ]; then echo "Missing environment variable ORGANIZATION."; exit 1 ; fi',
+                'if [ -z "${REPOSITORY}" ]; then echo "Missing environment variable REPOSITORY."; exit 1 ; fi',
+                'if [ -z "${PROJECT}" ]; then echo "Missing environment variable PROJECT."; exit 1 ; fi',
+                'if [ -z "${TOKEN}" ]; then echo "Missing environment variable TOKEN."; exit 1 ; fi',
+              ],
+              'on-failure': 'ABORT',
+            },
             build: {
               commands: [
                 'git clone --mirror "https://${TOKEN}@dev.azure.com/${ORGANIZATION}/${PROJECT}/_git/${REPOSITORY}"',


### PR DESCRIPTION
Fixes #36.
Added a check in the pre_build phase. If environment variables are missing, the build phase will not be executed.